### PR TITLE
Handle an event queue for each user

### DIFF
--- a/src/lib/eventRepository.ts
+++ b/src/lib/eventRepository.ts
@@ -1,0 +1,27 @@
+import { type Event } from '../types/event';
+
+export class EventRepository {
+	private playerEvents: { [playerCode: string]: Event[] };
+
+	constructor() {
+		this.playerEvents = {};
+	}
+
+	public async savePlayerEvent(playerCode: string, event: Event): Promise<void> {
+		if (!this.playerEvents[playerCode]) {
+			this.playerEvents[playerCode] = [];
+		}
+
+		this.playerEvents[playerCode].push(event);
+	}
+
+	public async getPlayerEvents(playerCode: string): Promise<Event[]> {
+		return Promise.resolve(this.playerEvents[playerCode] ?? []);
+	}
+
+	public async deletePlayerEvents(playerCode: string): Promise<void> {
+		delete this.playerEvents[playerCode];
+	}
+}
+
+export const eventRepository = new EventRepository();

--- a/src/lib/eventService.test.ts
+++ b/src/lib/eventService.test.ts
@@ -1,0 +1,3 @@
+import { describe } from 'vitest';
+
+describe.skip('EventService', () => {});

--- a/src/lib/eventService.test.ts
+++ b/src/lib/eventService.test.ts
@@ -1,5 +1,218 @@
-import { beforeEach, describe } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { EventService } from './eventService';
+import { GameRepository as InMemoryGameRepository } from './gameRepository';
+import { EventRepository as InMemoryEventRepository } from './eventRepository';
+import { GameService } from './gameService';
+import { Roller } from './roller';
+import { GameState } from '../types/types';
+import { GameBuilder } from './gameService.test';
+import {
+	EventType,
+	type BidEvent,
+	type ChallengeEvent,
+	type GameEndEvent,
+	type RoundStartEvent
+} from '../types/event';
 
-describe.skip('EventService', () => {
-	beforeEach(async () => {});
+describe('EventService', () => {
+	let gameService: GameService;
+	let getSpy: MockInstance;
+
+	let eventService: EventService;
+
+	beforeEach(() => {
+		const repository = new InMemoryGameRepository();
+		eventService = new EventService(new InMemoryEventRepository());
+		gameService = new GameService(repository, eventService, new Roller());
+
+		getSpy = vi.spyOn(repository, 'getGame');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('GameService Integration', () => {
+		it('creates a RoundStart event after the game has started', async () => {
+			const initialState = new GameBuilder()
+				.setState(GameState.Lobby)
+				.addPlayer('playerOne', 'p1', [1, 1, 1])
+				.addPlayer('playerTwo', 'p2', [1, 1, 1])
+				.addPlayer('playerThree', 'p3', [1, 1, 1])
+				.build();
+			getSpy.mockResolvedValue(initialState);
+
+			const playerOneToken = `${initialState.code}-${initialState.players[0].code}`;
+			await gameService.startGame(playerOneToken);
+			const events = (await gameService.getGame(playerOneToken)).events;
+
+			expect(events).toHaveLength(1);
+			const roundStartEvent = events[0] as RoundStartEvent;
+			expect(roundStartEvent.type).toBe(EventType.RoundStart);
+			expect(roundStartEvent.diceCounts).toStrictEqual([
+				{ name: 'playerOne', diceCount: 3 },
+				{ name: 'playerTwo', diceCount: 3 },
+				{ name: 'playerThree', diceCount: 3 }
+			]);
+		});
+
+		it('creates a RoundStart event and a Challenge event after a successful challenge', async () => {
+			const initialState = new GameBuilder()
+				.setState(GameState.InProgress)
+				.addPlayer('playerOne', 'p1', [2, 2])
+				.addPlayer('playerTwo', 'p2', [5])
+				.addPlayer('playerThree', 'p3', [6, 2, 2])
+				.setCurrentPlayer(0)
+				.setCurrentBid(5, 2)
+				.build();
+			getSpy.mockResolvedValue(initialState);
+
+			const playerOneToken = `${initialState.code}-${initialState.players[0].code}`;
+			await gameService.challengeBid(playerOneToken);
+			const events = (await gameService.getGame(playerOneToken)).events;
+
+			expect(events).toHaveLength(2);
+
+			const challengeEvent = events[0] as ChallengeEvent;
+			expect(challengeEvent.type).toBe(EventType.Challenge);
+			expect(challengeEvent.challengeSuccess).toBe(true);
+			expect(challengeEvent.challengerName).toBe('playerOne');
+			expect(challengeEvent.defenderName).toBe('playerThree');
+			expect(challengeEvent.dicePool).toStrictEqual([
+				{ name: 'playerOne', dice: [2, 2] },
+				{ name: 'playerTwo', dice: [5] },
+				{ name: 'playerThree', dice: [6, 2, 2] }
+			]);
+
+			const roundStartEvent = events[1] as RoundStartEvent;
+			expect(roundStartEvent.type).toBe(EventType.RoundStart);
+			expect(roundStartEvent.diceCounts).toStrictEqual([
+				{ name: 'playerOne', diceCount: 2 },
+				{ name: 'playerTwo', diceCount: 1 },
+				{ name: 'playerThree', diceCount: 2 }
+			]);
+		});
+
+		it('creates a RoundStart event and a Challenge event after a failed challenge', async () => {
+			const initialState = new GameBuilder()
+				.setState(GameState.InProgress)
+				.addPlayer('playerOne', 'p1', [1, 1, 1])
+				.addPlayer('playerTwo', 'p2', [1, 1, 1])
+				.addPlayer('playerThree', 'p3', [1, 1, 1])
+				.setCurrentPlayer(0)
+				.setCurrentBid(3, 1)
+				.build();
+			getSpy.mockResolvedValue(initialState);
+
+			const playerOneToken = `${initialState.code}-${initialState.players[0].code}`;
+			await gameService.challengeBid(playerOneToken);
+			const events = (await gameService.getGame(playerOneToken)).events;
+
+			expect(events).toHaveLength(2);
+
+			const challengeEvent = events[0] as ChallengeEvent;
+			expect(challengeEvent.type).toBe(EventType.Challenge);
+			expect(challengeEvent.challengeSuccess).toBe(false);
+			expect(challengeEvent.challengerName).toBe('playerOne');
+			expect(challengeEvent.defenderName).toBe('playerThree');
+			expect(challengeEvent.dicePool).toStrictEqual([
+				{ name: 'playerOne', dice: [1, 1, 1] },
+				{ name: 'playerTwo', dice: [1, 1, 1] },
+				{ name: 'playerThree', dice: [1, 1, 1] }
+			]);
+
+			const roundStartEvent = events[1] as RoundStartEvent;
+			expect(roundStartEvent.type).toBe(EventType.RoundStart);
+			expect(roundStartEvent.diceCounts).toStrictEqual([
+				{ name: 'playerOne', diceCount: 2 },
+				{ name: 'playerTwo', diceCount: 3 },
+				{ name: 'playerThree', diceCount: 3 }
+			]);
+		});
+
+		it('creates a GameEnd event and a Challenge event after a game-ending challenge', async () => {
+			const initialState = new GameBuilder()
+				.setState(GameState.InProgress)
+				.addPlayer('playerOne', 'p1', [2, 2])
+				.addPlayer('playerTwo', 'p2', [1])
+				.addPlayer('playerThree', 'p3', [])
+				.setCurrentPlayer(1)
+				.setCurrentBid(2, 2)
+				.build();
+			getSpy.mockResolvedValue(initialState);
+
+			const playerTwoToken = `${initialState.code}-${initialState.players[1].code}`;
+			await gameService.challengeBid(playerTwoToken);
+			const events = (await gameService.getGame(playerTwoToken)).events;
+
+			expect(events).toHaveLength(2);
+
+			const challengeEvent = events[0] as ChallengeEvent;
+			expect(challengeEvent.type).toBe(EventType.Challenge);
+			expect(challengeEvent.challengeSuccess).toBe(false);
+			expect(challengeEvent.challengerName).toBe('playerTwo');
+			expect(challengeEvent.defenderName).toBe('playerOne');
+			expect(challengeEvent.dicePool).toStrictEqual([
+				{ name: 'playerOne', dice: [2, 2] },
+				{ name: 'playerTwo', dice: [1] },
+				{ name: 'playerThree', dice: [] }
+			]);
+
+			const gameEndEvent = events[1] as GameEndEvent;
+			expect(gameEndEvent.type).toBe(EventType.GameEnd);
+			expect(gameEndEvent.winnerName).toBe('playerOne');
+		});
+
+		it('creates a Bid event after a player bids', async () => {
+			const initialState = new GameBuilder()
+				.setState(GameState.InProgress)
+				.addPlayer('playerOne', 'p1', [2, 2])
+				.addPlayer('playerTwo', 'p2', [1])
+				.addPlayer('playerThree', 'p3', [6, 1, 2])
+				.setCurrentPlayer(0)
+				.setCurrentBid(2, 2)
+				.build();
+			getSpy.mockResolvedValue(initialState);
+
+			const playerOneToken = `${initialState.code}-${initialState.players[0].code}`;
+			await gameService.placeBid(4, 2, playerOneToken);
+			const events = (await gameService.getGame(playerOneToken)).events;
+
+			expect(events).toHaveLength(1);
+
+			const bidEvent = events[0] as BidEvent;
+			expect(bidEvent.type).toBe(EventType.Bid);
+			expect(bidEvent.bid).toStrictEqual({ quantity: 4, dice: 2 });
+			expect(bidEvent.bidderName).toBe('playerOne');
+		});
+
+		it('builds up events until the player reads them', async () => {
+			const initialState = new GameBuilder()
+				.setState(GameState.InProgress)
+				.addPlayer('playerOne', 'p1', [2, 2, 1])
+				.addPlayer('playerTwo', 'p2', [1, 1, 1])
+				.addPlayer('playerThree', 'p3', [6, 1, 2])
+				.setCurrentPlayer(0)
+				.build();
+			getSpy.mockResolvedValue(initialState);
+
+			const p1Code = `${initialState.code}-${initialState.players[0].code}`;
+			const p2Code = `${initialState.code}-${initialState.players[1].code}`;
+			const p3Code = `${initialState.code}-${initialState.players[2].code}`;
+			await gameService.placeBid(1, 1, p1Code);
+			await gameService.placeBid(2, 1, p2Code);
+			await gameService.placeBid(2, 3, p3Code);
+			await gameService.placeBid(3, 1, p1Code);
+			await gameService.challengeBid(p2Code);
+
+			let p1Events = (await gameService.getGame(p1Code)).events;
+			expect(p1Events).toHaveLength(6);
+
+			p1Events = (await gameService.getGame(p1Code)).events;
+			expect(p1Events, 'the p1 message queue should be cleared').toHaveLength(0);
+
+			const p2Events = (await gameService.getGame(p2Code)).events;
+			expect(p2Events, 'the p2 message queue should not be cleared').toHaveLength(6);
+		});
+	});
 });

--- a/src/lib/eventService.test.ts
+++ b/src/lib/eventService.test.ts
@@ -1,3 +1,5 @@
-import { describe } from 'vitest';
+import { beforeEach, describe } from 'vitest';
 
-describe.skip('EventService', () => {});
+describe.skip('EventService', () => {
+	beforeEach(async () => {});
+});

--- a/src/lib/eventService.ts
+++ b/src/lib/eventService.ts
@@ -1,5 +1,13 @@
-import { EventType, type Event, type RoundStartEvent } from '../types/event';
-import type { Player } from '../types/types';
+import {
+	EventType,
+	type BidEvent,
+	type ChallengeEvent,
+	type Event,
+	type GameEndEvent,
+	type PeekEvent,
+	type RoundStartEvent
+} from '../types/event';
+import type { Bid, Player } from '../types/types';
 import { eventRepository, type EventRepository } from './eventRepository';
 
 export class EventService {
@@ -12,14 +20,74 @@ export class EventService {
 		return events;
 	}
 
-	public async recordRoundStart(players: Player[], roundNumber: number): Promise<void> {
+	public async recordRoundStart(players: Player[]): Promise<void> {
 		const event: RoundStartEvent = {
 			type: EventType.RoundStart,
-			roundNumber
+			diceCounts: players.map((p) => ({ name: p.name, diceCount: p.dice.length }))
 		};
 
 		for (const player of players) {
 			await this.repository.savePlayerEvent(player.code, event);
+		}
+	}
+
+	public async recordBidEvent(players: Player[], bid: Bid, biddingPlayer: Player): Promise<void> {
+		const event: BidEvent = {
+			type: EventType.Bid,
+			bid,
+			bidderName: biddingPlayer.name
+		};
+
+		for (const player of players) {
+			if (player.name !== biddingPlayer.name) {
+				await this.repository.savePlayerEvent(player.code, event);
+			}
+		}
+	}
+
+	public async recordChallengeEvent(
+		players: Player[],
+		bid: Bid,
+		challenger: Player,
+		defender: Player,
+		challengeSuccess: boolean
+	): Promise<void> {
+		const dicePool = players.map((p) => ({ name: p.name, dice: p.dice }));
+		const event: ChallengeEvent = {
+			type: EventType.Challenge,
+			challengerName: challenger.name,
+			defenderName: defender.name,
+			bid,
+			dicePool,
+			challengeSuccess
+		};
+
+		for (const player of players) {
+			await this.repository.savePlayerEvent(player.code, event);
+		}
+	}
+
+	public async recordGameEndEvent(players: Player[], winnerName: string): Promise<void> {
+		const event: GameEndEvent = {
+			type: EventType.GameEnd,
+			winnerName
+		};
+
+		for (const player of players) {
+			await this.repository.savePlayerEvent(player.code, event);
+		}
+	}
+
+	public async recordPeekEvent(players: Player[], peekerName: string): Promise<void> {
+		const event: PeekEvent = {
+			type: EventType.Peek,
+			peekerName
+		};
+
+		for (const player of players) {
+			if (player.name !== peekerName) {
+				await this.repository.savePlayerEvent(player.code, event);
+			}
 		}
 	}
 }

--- a/src/lib/eventService.ts
+++ b/src/lib/eventService.ts
@@ -39,9 +39,7 @@ export class EventService {
 		};
 
 		for (const player of players) {
-			if (player.name !== biddingPlayer.name) {
-				await this.repository.savePlayerEvent(player.code, event);
-			}
+			await this.repository.savePlayerEvent(player.code, event);
 		}
 	}
 
@@ -52,7 +50,7 @@ export class EventService {
 		defender: Player,
 		challengeSuccess: boolean
 	): Promise<void> {
-		const dicePool = players.map((p) => ({ name: p.name, dice: p.dice }));
+		const dicePool = players.map((p) => ({ name: p.name, dice: [...p.dice] }));
 		const event: ChallengeEvent = {
 			type: EventType.Challenge,
 			challengerName: challenger.name,

--- a/src/lib/eventService.ts
+++ b/src/lib/eventService.ts
@@ -1,0 +1,27 @@
+import { EventType, type Event, type RoundStartEvent } from '../types/event';
+import type { Player } from '../types/types';
+import { eventRepository, type EventRepository } from './eventRepository';
+
+export class EventService {
+	constructor(private repository: EventRepository) {}
+
+	public async popPlayerEvents(playerCode: string): Promise<Event[]> {
+		const events = await this.repository.getPlayerEvents(playerCode);
+		await this.repository.deletePlayerEvents(playerCode);
+
+		return events;
+	}
+
+	public async recordRoundStart(players: Player[], roundNumber: number): Promise<void> {
+		const event: RoundStartEvent = {
+			type: EventType.RoundStart,
+			roundNumber
+		};
+
+		for (const player of players) {
+			await this.repository.savePlayerEvent(player.code, event);
+		}
+	}
+}
+
+export const eventService = new EventService(eventRepository);

--- a/src/lib/gameService.test.ts
+++ b/src/lib/gameService.test.ts
@@ -5,7 +5,7 @@ import { GameState, type Game, type Player } from '../types/types';
 import { Roller } from './roller';
 import type { PlayerDto } from '../types/dtos';
 import { EventService } from './eventService';
-import { EventRepository } from './eventRepository';
+import { EventRepository as InMemoryEventRepository } from './eventRepository';
 
 const MOCK_RANDOM = 'aRandomValue';
 const MOCK_START_PLAYER = 1;
@@ -26,7 +26,7 @@ describe('GameService', () => {
 	beforeEach(() => {
 		repository = new GameRepository();
 		roller = new Roller();
-		events = new EventService(new EventRepository());
+		events = new EventService(new InMemoryEventRepository());
 		service = new GameService(repository, events, roller);
 		savedGame = undefined;
 

--- a/src/lib/gameService.test.ts
+++ b/src/lib/gameService.test.ts
@@ -4,6 +4,8 @@ import { GameRepository } from './gameRepository';
 import { GameState, type Game, type Player } from '../types/types';
 import { Roller } from './roller';
 import type { PlayerDto } from '../types/dtos';
+import { EventService } from './eventService';
+import { EventRepository } from './eventRepository';
 
 const MOCK_RANDOM = 'aRandomValue';
 const MOCK_START_PLAYER = 1;
@@ -16,13 +18,16 @@ describe('GameService', () => {
 	let saveSpy: MockInstance;
 	let getSpy: MockInstance;
 
+	let events: EventService;
+
 	let roller: Roller;
 	let rollSpy: MockInstance;
 
 	beforeEach(() => {
 		repository = new GameRepository();
 		roller = new Roller();
-		service = new GameService(repository, roller);
+		events = new EventService(new EventRepository());
+		service = new GameService(repository, events, roller);
 		savedGame = undefined;
 
 		saveSpy = vi.spyOn(repository, 'saveGame');
@@ -633,7 +638,7 @@ describe('GameService', () => {
 	});
 });
 
-class GameBuilder {
+export class GameBuilder {
 	private game: Game;
 
 	constructor() {

--- a/src/types/dtos.ts
+++ b/src/types/dtos.ts
@@ -1,8 +1,10 @@
+import type { Event } from './event';
 import type { Bid, GameState } from './types';
 
 export type GameDto = {
 	players: PlayerDto[];
 	state: GameState;
+	events: Event[];
 };
 
 export type PlayerDto = {

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,6 +1,6 @@
 import { type Bid } from './types';
 
-export type Event = RoundStartEvent | PeekEvent | ChallengeEvent | BidEvent;
+export type Event = RoundStartEvent | PeekEvent | ChallengeEvent | BidEvent | GameEndEvent;
 
 export enum EventType {
 	RoundStart = 'RoundStart',
@@ -12,7 +12,7 @@ export enum EventType {
 
 export interface RoundStartEvent {
 	type: EventType.RoundStart;
-	roundNumber: number;
+	diceCounts: { name: string; diceCount: number }[];
 }
 
 export interface PeekEvent {
@@ -25,6 +25,8 @@ export interface ChallengeEvent {
 	challengerName: string;
 	defenderName: string;
 	dicePool: { name: string; dice: number[] }[];
+	bid: Bid;
+	challengeSuccess: boolean;
 }
 
 export interface BidEvent {

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,0 +1,39 @@
+import { type Bid } from './types';
+
+export type Event = RoundStartEvent | PeekEvent | ChallengeEvent | BidEvent;
+
+export enum EventType {
+	RoundStart = 'RoundStart',
+	Peek = 'Peek',
+	Challenge = 'Challenge',
+	Bid = 'Bid',
+	GameEnd = 'GameEnd'
+}
+
+export interface RoundStartEvent {
+	type: EventType.RoundStart;
+	roundNumber: number;
+}
+
+export interface PeekEvent {
+	type: EventType.Peek;
+	peekerName: string;
+}
+
+export interface ChallengeEvent {
+	type: EventType.Challenge;
+	challengerName: string;
+	defenderName: string;
+	dicePool: { name: string; dice: number[] }[];
+}
+
+export interface BidEvent {
+	type: EventType.Bid;
+	bidderName: string;
+	bid: Bid;
+}
+
+export interface GameEndEvent {
+	type: EventType.GameEnd;
+	winnerName: string;
+}


### PR DESCRIPTION
Created the `EventService`, which tracks a list of unread game events for each player. Each event has enough information on it for the client to display information about the event which it wouldn't get by polling the game state. For instance, a `ChallengeEvent` contains the dice pool at the point of the challenge, and the `RoundStartEvent` has the dice count for each player. By tracking what each player has already seen, the server doesn't need to worry about how often the game state is being polled.

The `GameService.getGame()` method will read from the calling player's event queue and return the events.

Future bot implementations could also read from this queue to help make decisions.